### PR TITLE
added register.jl

### DIFF
--- a/register.jl
+++ b/register.jl
@@ -3,10 +3,9 @@ using Stipple, StippleUI
 Base.@kwdef mutable struct RegistrationModel <: ReactiveModel
   name::R{String} = ""
   email::R{String} = ""
-  registered_email::R{Bool} = false
+  new_email::R{Bool} = true
   password::R{String} = ""
-  signup::R{Bool} = false
-  # disable::R{Bool} = true
+  submit::R{Bool} = false
 end
 
 model = Stipple.init(RegistrationModel())
@@ -16,50 +15,38 @@ email_db = Set(["a@b.com", "aa@bb.com"])
 
 # for each email, check to see if it's already registered in our database
 on(model.email) do email
-  model.registered_email[] = email ∈ email_db
+  model.new_email[] = email ∉ email_db
 end
 
 # these are the tests to see if input is valid or not, except for checking if an email is already registered or not, all of these are done on the client and not on the server: winning!
-Stipple.js_computed(model::RegistrationModel) = """
-  email_msg: function () {
-    if (this.email.length == 0) {
-      return 'email cannot be empty'
-    } else if (this.registered_email) {
-      return 'email already registered in our database'
-    } else {
-      return ''
+Stipple.js_methods(model::RegistrationModel) = """
+myRule (val) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(!val || this.new_email || 'email already registered in our database')
+    }, 1000)
+  })
+},
+onSubmit () {
+        this.\$q.notify({
+          color: 'green-4',
+          textColor: 'white',
+          icon: 'cloud_done',
+          message: 'Submitted'
+        })
     }
-  },
-  name_msg: function () {
-    if (this.name.length == 0) {
-      return 'name cannot be empty'
-    } else {
-      return ''
-    }
-  },
-  password_msg: function () {
-    if (this.password.length == 0) {
-      return 'password cannot be empty'
-    } else {
-      return ''
-    }
-  }
 """
 
 function register()
   app = dashboard(vm(model),
                   [
                    heading("Registration"),
-                   row(cell(class="st-module", [
-                                                p(["Name", input("", placeholder="Type your name", @bind(:name), type = "text")]),
-                                                p([span("", @text(:name_msg))]),
-                                                p(["Email", input("", placeholder="Type your email", @bind(:email), type = "email")]),
-                                                p([span("", @text(:email_msg))]),
-                                                p(["Password", input("", placeholder="Type a password", @bind(:password), type = "password")]),
-                                                p([span("", @text(:password_msg))]),
-                                                p(btn("Sign up", @click(:signup), disable = :disable)),
-                                               ])),
-                  ], title = "Registration")
+                                                Stipple.form([
+                                                textfield("Your name *", :name, type = "text", filled = true, hint="Name and surname", lazy_rules = true, rules="[ val => val && val.length > 0 || 'Please type something' ]"),
+                                                textfield("Your email *", :email, type = "email", filled = true, hint="Email", lazy_rules = true, rules="[ val => val && val.length > 0 || 'Please type something']"), # add this if you want to have the server side checks for an already registered email:         , myRule ]"),
+                                                textfield("Password *", :password, type = "password", filled = true, hint="A password", lazy_rules = true, rules="[ val => val && val.length > 0 || 'Please type something' ]"),
+                                                btn("Sign up", @click("onSubmit"), type = "submit")
+                                               ]), ])
   html(app)
 end
 

--- a/register.jl
+++ b/register.jl
@@ -1,0 +1,68 @@
+using Stipple, StippleUI
+
+Base.@kwdef mutable struct RegistrationModel <: ReactiveModel
+  name::R{String} = ""
+  email::R{String} = ""
+  registered_email::R{Bool} = false
+  password::R{String} = ""
+  signup::R{Bool} = false
+  # disable::R{Bool} = true
+end
+
+model = Stipple.init(RegistrationModel())
+
+# a database of registered emails
+email_db = Set(["a@b.com", "aa@bb.com"])
+
+# for each email, check to see if it's already registered in our database
+on(model.email) do email
+  model.registered_email[] = email ∈ email_db
+end
+
+# these are the tests to see if input is valid or not, except for checking if an email is already registered or not, all of these are done on the client and not on the server: winning!
+Stipple.js_computed(model::RegistrationModel) = """
+  email_msg: function () {
+    if (this.email.length == 0) {
+      return 'email cannot be empty'
+    } else if (this.registered_email) {
+      return 'email already registered in our database'
+    } else {
+      return ''
+    }
+  },
+  name_msg: function () {
+    if (this.name.length == 0) {
+      return 'name cannot be empty'
+    } else {
+      return ''
+    }
+  },
+  password_msg: function () {
+    if (this.password.length == 0) {
+      return 'password cannot be empty'
+    } else {
+      return ''
+    }
+  }
+"""
+
+function register()
+  app = dashboard(vm(model),
+                  [
+                   heading("Registration"),
+                   row(cell(class="st-module", [
+                                                p(["Name", input("", placeholder="Type your name", @bind(:name), type = "text")]),
+                                                p([span("", @text(:name_msg))]),
+                                                p(["Email", input("", placeholder="Type your email", @bind(:email), type = "email")]),
+                                                p([span("", @text(:email_msg))]),
+                                                p(["Password", input("", placeholder="Type a password", @bind(:password), type = "password")]),
+                                                p([span("", @text(:password_msg))]),
+                                                p(btn("Sign up", @click(:signup), disable = :disable)),
+                                               ])),
+                  ], title = "Registration")
+  html(app)
+end
+
+route("/", register)
+up(open_browser = true)
+


### PR DESCRIPTION
This is an example of a registration page. The idea here is to show how client- and server-side validations can work together. 

While it currently works, because the input fields are of course initially empty/invalid, the computed validations cause the warning messages to show, right from the getgo:
![screenshot_2021-06-10_15:09:52](https://user-images.githubusercontent.com/3281957/121531891-20426e00-c9ff-11eb-96da-d30cbc1d9ca4.jpg)
I'm not sure how to avoid that, so any help from the wizards would be awesome :heart: 

After that, I plan to tie these validations to dis/enable the `Sign up` button, so you won't be able to even press it *unless* the validations pass.